### PR TITLE
Re-order deferred result append and Done

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,6 +204,8 @@ func doMain() error {
 		}
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
+			
 			sema <- 1 // acquire token
 			defer func() {
 				<-sema // release token
@@ -213,14 +215,7 @@ func doMain() error {
 				fset:  fset,
 				query: query,
 			}
-			defer func() {
-				mutex.Lock()
-				syms = append(syms, v.syms...)
-				mutex.Unlock()
-			}()
 
-			defer wg.Done()
-			
 			if haveSrcDir {
 				path = filepath.Join(dir, "src", path)
 			} else {
@@ -236,6 +231,9 @@ func doMain() error {
 					ast.Inspect(f, v.Visit)
 				}
 			}
+			mutex.Lock()
+			syms = append(syms, v.syms...)
+			mutex.Unlock()
 		}()
 	})
 	wg.Wait()


### PR DESCRIPTION
As it was, the `Done` call would be executed before the append, since deferred are run LIFO.
This meant that the program could continue before the full results were appended.

As there are no early returns, moving the append out of a defer works just as well (and eliminates questions about execution order).

Fixes #5.